### PR TITLE
Fixed function not found on undefined objects when rendering end states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,4 @@ out
 # OSX
 .DS_Store
 
-snakebot-js/node_modules
-
+node_modules

--- a/domain/mapRenderer.js
+++ b/domain/mapRenderer.js
@@ -83,8 +83,19 @@ function MapRendererDoT(){
       updateGameSnakes(tick, gameSnakes, gameState, gameEvents);
       renderGameState(gameState, gameSnakes, debugData);
     }
-    renderEndOfGame(gameSnakes, gameStates[totalTicks - 1], recordedGameEvents[totalTicks - 1]);
+
+    renderEndOfGame(gameSnakes, getGameEndedEvent(gameStates), recordedGameEvents[totalTicks - 1]);
     onComplete ? onComplete() : 0;
+  }
+
+  function getGameEndedEvent(gameStates) {
+
+    var tickKeys = Object.keys(gameStates);
+    var key = tickKeys.find(function (tick) {
+      return gameStates[tick].type === 'se.cygni.snake.api.event.GameEndedEvent'
+    });
+
+    return gameStates[key];
   }
 
   function renderAnimated(gameStates, settings, onComplete){
@@ -109,7 +120,8 @@ function MapRendererDoT(){
         if (renderIdx < totalTicks) {
           renderStates();
         }  else {
-          renderEndOfGame(gameSnakes, gameStates[tick]);
+          console.log(JSON.stringify(gameStates));
+          renderEndOfGame(gameSnakes, getGameEndedEvent(gameStates));
           onComplete ? onComplete() : 0;
         }
       }, settings.delay);

--- a/snake-cli.js
+++ b/snake-cli.js
@@ -63,10 +63,10 @@ function endGame(exit){
   var fProcEnd = exit ? function(){process.exit()} : 0;
   snakeBot.gameEnded();
 
-  if(options.gamelink){
+  if(options.gamelink && gameLink){
     open(gameLink.getUrl());
   } else {
-    log("GameLink: " + gameLink.getUrl());
+    log("GameLink: " + (gameLink ? gameLink.getUrl() : 'no GameLink received'));
   }
 
   if(options.renderMode == 'norender'){


### PR DESCRIPTION
It seems that the GameResult can be null and therefore kills part of the debug printouts with a stack trace. 

Also, the storage of gameStates in mapRenderer.js is tricky. Unclear why a map was choosen but the way to find the GameEndedEvent is not fail safe. When in tournament mode a bot that dies in the middle of the game does not any longer receive mapUpdateEvents. This means that the GameEndedEvent is not on the key totalTicks-1. Changed it to a classic (but rather ugly) lookup. Feel free to make a better solution!

Added node_modules with correct path to .gitignore